### PR TITLE
Better Qt5 support

### DIFF
--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -13,7 +13,7 @@
 #include <QQmlEngine>
 #endif
 
-#include <qzxingimageprovider.h>
+#include "QZXingImageProvider.h"
 
 // forward declaration
 namespace zxing {

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -120,8 +120,8 @@ public slots:
      * of a portion of the image. (Suggested for Qt 4.x)
      */
     QString decodeSubImageQML(QObject *item,
-                              const double offsetX = 0 , const double offsetY = 0,
-                              const double width = 0, const double height = 0);
+                              const int offsetX = 0, const int offsetY = 0,
+                              const int width = 0, const int height = 0);
 
     /**
      * The decoding function accessible from QML. (Suggested for Qt 5.x)
@@ -138,8 +138,8 @@ public slots:
      * (Suggested for Qt 5.x)
      */
     QString decodeSubImageQML(const QUrl &imageUrl,
-                              const double offsetX = 0, const double offsetY = 0,
-                              const double width = 0, const double height = 0);
+                              const int offsetX = 0, const int offsetY = 0,
+                              const int width = 0, const int height = 0);
 
     /**
      * The main encoding function. Currently supports only Qr code encoding

--- a/src/imagehandler.cpp
+++ b/src/imagehandler.cpp
@@ -4,16 +4,37 @@
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
 #include <QDebug>
+#include <QQuickItem>
+#include <QQuickItemGrabResult>
+#include <QQuickWindow>
+#include <QThread>
+#include <QTime>
 
 ImageHandler::ImageHandler(QObject *parent) :
     QObject(parent)
 {
 }
 
-QImage ImageHandler::extractQImage(QObject *imageObj,
-                                   const double offsetX, const double offsetY,
-                                   const double width, const double height)
+QImage ImageHandler::extractQImage(QObject *imageObj, int offsetX, int offsetY, int width, int height)
 {
+#if QT_VERSION >= 0x050000
+    QQuickItem *item = qobject_cast<QQuickItem *>(imageObj);
+
+    if (!item || !item->window()->isVisible()) {
+        qDebug() << "Item is NULL";
+        return QImage();
+    }
+
+    bool imgReady = false;
+    QTime timer;
+    timer.start();
+    auto img = item->grabToImage();
+    connect(img.data(), &QQuickItemGrabResult::ready, this, [&imgReady](){imgReady = true;});
+    while (!imgReady && timer.elapsed() < 1000) {
+        qApp->processEvents();
+        QThread::yieldCurrentThread();
+    }
+#else
     QGraphicsObject *item = qobject_cast<QGraphicsObject*>(imageObj);
 
     if (!item) {
@@ -26,18 +47,26 @@ QImage ImageHandler::extractQImage(QObject *imageObj,
     QPainter painter(&img);
     QStyleOptionGraphicsItem styleOption;
     item->paint(&painter, &styleOption);
+#endif
 
-    if(offsetX == 0 && offsetY == 0 && width == 0 && height == 0)
-        return img;
+    if (offsetX < 0)
+        offsetX = 0;
+    if (offsetY < 0)
+        offsetY = 0;
+    if (width < 0)
+        width = 0;
+    if (height < 0)
+        height = 0;
+
+    if (offsetX || offsetY || width || height)
+        return img->image().copy(offsetX, offsetY, width, height);
     else
-    {
-        return img.copy(offsetX, offsetY, width, height);
-    }
+        return img->image();
 }
 
 void ImageHandler::save(QObject *imageObj, const QString &path,
-                        const double offsetX, const double offsetY,
-                        const double width, const double height)
+                        const int offsetX, const int offsetY,
+                        const int width, const int height)
 {
     QImage img = extractQImage(imageObj, offsetX, offsetY, width, height);
     img.save(path);

--- a/src/imagehandler.h
+++ b/src/imagehandler.h
@@ -11,13 +11,13 @@ public:
     explicit ImageHandler(QObject *parent = 0);
 
     QImage extractQImage(QObject *imageObj,
-                         const double offsetX = 0 , const double offsetY = 0,
-                         const double width = 0, const double height = 0);
+                         int offsetX = 0, int offsetY = 0,
+                         int width = 0, int height = 0);
 
 public slots:
     void save(QObject *item, const QString &path,
-              const double offsetX = 0, const double offsetY = 0,
-              const double width = 0, const double height = 0);
+              const int offsetX = 0, const int offsetY = 0,
+              const int width = 0, const int height = 0);
 };
 
 #endif // IMAGEHANDLER_H

--- a/src/imagehandler.h
+++ b/src/imagehandler.h
@@ -3,6 +3,10 @@
 
 #include <QObject>
 #include <QImage>
+#if QT_VERSION >= 0x050000
+#include <QSet>
+#include <QReadWriteLock>
+#endif
 
 class ImageHandler : public QObject
 {
@@ -18,6 +22,12 @@ public slots:
     void save(QObject *item, const QString &path,
               const int offsetX = 0, const int offsetY = 0,
               const int width = 0, const int height = 0);
+private:
+#if QT_VERSION >= 0x050000
+    void imageGrabberReady();
+    QSet<QObject *> pendingGrabbers;
+    QReadWriteLock pendingGrabbersLocker;
+#endif
 };
 
 #endif // IMAGEHANDLER_H


### PR DESCRIPTION
- Proper support for QQuickItem passed to extractQImage
- Proper support for QML Camera captured images
- There is no need to have offset and size in double due to passing it to QImage::copy which accepts only integers