### PR TITLE
QZXingLive example: remove unused qzxing.h include

### DIFF
--- a/examples/QZXingLive/main.cpp
+++ b/examples/QZXingLive/main.cpp
@@ -4,7 +4,6 @@
 
 #include <QDebug>
 
-#include <qzxing.h>
 #include <Qt>
 #include "QZXingFilter.h"
 


### PR DESCRIPTION
qzxing.h doesn't exist, and the example works fine without it.