### PR TITLE
QZXingLive fix for Android

### DIFF
--- a/examples/QZXingLive/QZXingFilter.h
+++ b/examples/QZXingLive/QZXingFilter.h
@@ -86,7 +86,7 @@ class QZXingFilter : public QAbstractVideoFilter
 
         QVideoFilterRunnable * createFilterRunnable();
 
-        static QImage fromBGRAtoARGB(uchar * data, QSize size, QVideoFrame::PixelFormat pixelFormat);
+        static QImage fromBGRAtoARGB(uchar * data, int dataSize, QSize size, QVideoFrame::PixelFormat pixelFormat);
 };
 
 /// A new Runnable is created everytime the filter gets a new frame


### PR DESCRIPTION
We had an issue on Android where the QZXing live demo would crash.

It looks like the fromBGRAtoARGB function would either:
- have a null image, 
- or it would go out of the range of the image.bits(), manipulating data addresses outside of it's own array.