### PR TITLE
Define static function to registers types in qzxing.cpp, not in qzxing.h

### DIFF
--- a/src/QZXing
+++ b/src/QZXing
@@ -1,0 +1,5 @@
+#include "QZXing.h"
+#include "QZXingImageProvider.h"
+#ifdef QZXING_MULTIMEDIA
+#include "QZXingFilter.h"
+#endif //QZXING_MULTIMEDIA

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -5,19 +5,11 @@
 #include <QObject>
 #include <QImage>
 
-#if QT_VERSION >= 0x040700 && QT_VERSION < 0x050000
-#include <QtDeclarative>
-#elif QT_VERSION >= 0x050000
-#include <QtQml/qqml.h>
-#include <QQuickView>
-#include <QQmlEngine>
+#if QT_VERSION >= 0x050000
+class QQuickView;
 #endif
 
 #include "QZXingImageProvider.h"
-
-#ifdef QZXING_MULTIMEDIA
-#include "QZXingFilter.h"
-#endif//#ifdef QZXING_MULTIMEDIA
 
 // forward declaration
 namespace zxing {
@@ -80,23 +72,11 @@ public:
 #ifdef QZXING_QML
 
 #if QT_VERSION >= 0x040700
-    static void registerQMLTypes()
-    {
-        qmlRegisterType<QZXing>("QZXing", 2, 3, "QZXing");
-
-#ifdef QZXING_MULTIMEDIA
-        qmlRegisterType<QZXingFilter>("QZXing", 2, 3, "QZXingFilter");
-#endif //QZXING_MULTIMEDIA
-
-    }
+    static void registerQMLTypes();
 #endif //QT_VERSION >= Qt 4.7
 
 #if  QT_VERSION >= 0x050000
-    static void registerQMLImageProvider(const QQuickView& view)
-    {
-        QQmlEngine *engine = view.engine();
-        engine->addImageProvider(QLatin1String("QZXing"), QZXingImageProvider::getInstance());
-    }
+    static void registerQMLImageProvider(const QQuickView& view);
 #endif //QT_VERSION >= Qt 5.0
 
 #endif //QZXING_QML

--- a/src/QZXingFilter.cpp
+++ b/src/QZXingFilter.cpp
@@ -1,6 +1,5 @@
 #include "QZXingFilter.h"
 
-#include <QZXing.h>
 #include <QDebug>
 #include <QtConcurrent/QtConcurrent>
 
@@ -27,30 +26,18 @@ namespace {
 
 QZXingFilter::QZXingFilter(QObject *parent)
     : QAbstractVideoFilter(parent)
-    , decoder_p(new QZXing())
     , decoding(false)
 {
     /// Conecting signals to handlers that will send signals to QML
-    connect(decoder_p, &QZXing::decodingStarted,
+    connect(&decoder, &QZXing::decodingStarted,
             this, &QZXingFilter::handleDecodingStarted);
-    connect(decoder_p, &QZXing::decodingFinished,
+    connect(&decoder, &QZXing::decodingFinished,
             this, &QZXingFilter::handleDecodingFinished);
 }
 
 QZXingFilter::~QZXingFilter()
 {
-    if(decoder_p)
-        delete decoder_p;
-}
 
-bool QZXingFilter::isDecoding()
-{
-    return decoding;
-}
-
-QZXing *QZXingFilter::getDecoder()
-{
-    return decoder_p;
 }
 
 void QZXingFilter::handleDecodingStarted()
@@ -63,7 +50,7 @@ void QZXingFilter::handleDecodingStarted()
 void QZXingFilter::handleDecodingFinished(bool succeeded)
 {
     decoding = false;
-    emit decodingFinished(succeeded, decoder_p->getProcessTimeOfLastDecoding());
+    emit decodingFinished(succeeded, decoder.getProcessTimeOfLastDecoding());
     emit isDecodingChanged();
 }
 
@@ -261,22 +248,22 @@ void QZXingFilterRunnable::processVideoFrameProbed(SimpleVideoFrame & videoFrame
 //    const QString path = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation) + "/qrtest/test_" + QString::number(i % 100) + ".png";
 //    qDebug() << "saving image" << i << "at:" << path << image.save(path);
 
-    QString tag = filter->decoder_p->decodeImage(image, image.width(), image.height());
+    QString tag = filter->decoder.decodeImage(image, image.width(), image.height());
 
-    const bool tryHarder = filter->decoder_p->getTryHarder();
+    const bool tryHarder = filter->decoder.getTryHarder();
     /// The frames we get from the camera may be reflected horizontally or vertically
     /// As the decoder can't handle reflected frames, we swap them in all possible frames, changing the swap mode each frame.
     /// TODO: Maybe there is a better way to know this orientation beforehand? Or should we try decoding all of them?
     if (tag.isEmpty() && tryHarder) {
         image = image.mirrored(true, false);
-        tag = filter->decoder_p->decodeImage(image, image.width(), image.height());
+        tag = filter->decoder.decodeImage(image, image.width(), image.height());
     }
     if (tag.isEmpty() && tryHarder) {
         image = image.mirrored(false, true);
-        tag = filter->decoder_p->decodeImage(image, image.width(), image.height());
+        tag = filter->decoder.decodeImage(image, image.width(), image.height());
     }
     if (tag.isEmpty() && tryHarder) {
         image = image.mirrored(true, true);
-        tag = filter->decoder_p->decodeImage(image, image.width(), image.height());
+        tag = filter->decoder.decodeImage(image, image.width(), image.height());
     }
 }

--- a/src/QZXingFilter.h
+++ b/src/QZXingFilter.h
@@ -5,9 +5,7 @@
 #include <QAbstractVideoFilter>
 #include <QDebug>
 #include <QFuture>
-
-//forward declaration
-class QZXing;
+#include <QZXing.h>
 
 ///
 /// References:
@@ -77,7 +75,7 @@ class QZXingFilter : public QAbstractVideoFilter
         void handleDecodingFinished(bool succeeded);
 
     private: /// Attributes
-        QZXing* decoder_p;
+        QZXing decoder;
         bool decoding;
         QRectF captureRect;
 
@@ -88,10 +86,8 @@ class QZXingFilter : public QAbstractVideoFilter
         explicit QZXingFilter(QObject *parent = 0);
         virtual ~QZXingFilter();
 
-        bool isDecoding();
-        QZXing* getDecoder();
-//        bool isDecoding() {return decoding; }
-//        QZXing* getDecoder() { return &decoder; }
+        bool isDecoding() {return decoding; }
+        QZXing* getDecoder() { return &decoder; }
 
         QVideoFilterRunnable * createFilterRunnable();
 };

--- a/src/qzxing.cpp
+++ b/src/qzxing.cpp
@@ -19,6 +19,18 @@
 #include <QQmlContext>
 #include <QQuickImageProvider>
 
+
+#if QT_VERSION >= 0x040700 && QT_VERSION < 0x050000
+#include <QtDeclarative>
+#elif QT_VERSION >= 0x050000
+#include <QtQml/qqml.h>
+#include <QQuickView>
+#endif
+
+#include "QZXingFilter.h"
+#include "QZXingImageProvider.h"
+
+
 using namespace zxing;
 
 QZXing::QZXing(QObject *parent) : QObject(parent), tryHarder_(false)
@@ -60,6 +72,30 @@ QZXing::QZXing(QZXing::DecoderFormat decodeHints, QObject *parent) : QObject(par
 
     setDecoder(decodeHints);
 }
+
+#ifdef QZXING_QML
+
+#if QT_VERSION >= 0x040700
+void QZXing::registerQMLTypes()
+{
+    qmlRegisterType<QZXing>("QZXing", 2, 3, "QZXing");
+
+#ifdef QZXING_MULTIMEDIA
+    qmlRegisterType<QZXingFilter>("QZXing", 2, 3, "QZXingFilter");
+#endif //QZXING_MULTIMEDIA
+
+}
+#endif //QT_VERSION >= Qt 4.7
+
+#if  QT_VERSION >= 0x050000
+void QZXing::registerQMLImageProvider(const QQuickView& view)
+{
+    QQmlEngine *engine = view.engine();
+    engine->addImageProvider(QLatin1String("QZXing"), QZXingImageProvider::getInstance());
+}
+#endif //QT_VERSION >= Qt 5.0
+
+#endif //QZXING_QML
 
 void QZXing::setTryHarder(bool tryHarder)
 {


### PR DESCRIPTION
This simplifies the code for QZXingFilter (revert it to what it was before)
Also added a global include file, to include all QZXing user classes.

Reverts 5627d2fbb549f24cf85afa51947eda6a5418009e, eb6bdb41e984c8e38ecb60561470748d87cfd813, 1bae4983861d779458642dd08feaf946d876e18d & 213c4d684bdcf143bc0bb4b665dd074d0e29cbd6

I'd argue that the `QZXing` extensionless header is not even needed since you don't need to include QZXingFilter or QZXingImageProvider to use them from QML.