### PR TITLE
Declarative encoding API from QML

### DIFF
--- a/examples/BarcodeEncoder/main.qml
+++ b/examples/BarcodeEncoder/main.qml
@@ -1,51 +1,34 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.0
-import QZXing 2.3
+import QtQuick.Layouts 1.3
 
 ApplicationWindow {
     visible: true
     width: 640
     height: 480
 
-    TextField {
-        id: inputField
-        anchors.left: parent.left
-        anchors.right: submit.left
-        anchors.top: parent.top
-        anchors.margins: 10
-    }
-
-    Button {
-        id: submit
-        anchors.right: parent.right
-        anchors.top: parent.top
-        text: "encode"
-        anchors.margins: 10
-        onClicked: {
-            qzxing.encodeData(inputField.text)
-            inputField.text = '';
-            resultImage.source = "";
-            resultImage.source = "image://QZXing/latestEncoded";
+    ColumnLayout {
+        anchors {
+            fill: parent
+            margins: 10
         }
-    }
-
-    GroupBox {
-        anchors.top: inputField.bottom
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.margins: 10
-        title: "Result barcode image"
-        clip: true
-
-        Image{
-            id:resultImage
-            anchors.centerIn: parent
-            cache: false;
+        TextField {
+            id: inputField
+            Layout.fillWidth: true
+            selectByMouse: true
+            text: "Hello world!"
         }
-    }
-
-    QZXing {
-        id: qzxing
+        GroupBox {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            title: "Result barcode image"
+            clip: true
+            Image{
+                id:resultImage
+                anchors.centerIn: parent
+                source: "image://QZXing/qrcode/" + inputField.text
+                cache: false;
+            }
+        }
     }
 }

--- a/src/QZXing.cpp
+++ b/src/QZXing.cpp
@@ -92,7 +92,7 @@ void QZXing::registerQMLTypes()
 #if  QT_VERSION >= 0x050000
 void QZXing::registerQMLImageProvider(QQmlEngine& engine)
 {
-    engine.addImageProvider(QLatin1String("QZXing"), QZXingImageProvider::getInstance());
+    engine.addImageProvider(QLatin1String("QZXing"), new QZXingImageProvider());
 }
 #endif //QT_VERSION >= Qt 5.0
 
@@ -501,9 +501,6 @@ QImage QZXing::encodeData(const QString& data)
                                    qRgb(255,255,255));
 
         image = image.scaled(240, 240);
-#ifdef QZXING_QML
-        QZXingImageProvider::getInstance()->storeImage(image);
-#endif //QZXING_QML
     } catch (std::exception& e) {
         std::cout << "Error: " << e.what() << std::endl;
     }

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -153,7 +153,7 @@ public slots:
     /**
      * The main encoding function. Currently supports only Qr code encoding
      */
-    QImage encodeData(const QString& data);
+    static QImage encodeData(const QString& data);
 
     /**
       * Get the prossecing time in millisecond of the last decode operation.

--- a/src/QZXingImageProvider.h
+++ b/src/QZXingImageProvider.h
@@ -23,16 +23,9 @@
 
 class QZXingImageProvider : public QQuickImageProvider
 {
-private:
-    QPixmap storedPixmap;
-    static QZXingImageProvider *singletonInstance_ptr_;
-protected:
-    QZXingImageProvider();
 public:
-    QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
-    void storeImage(const QImage& providedImage);
-
-    static QZXingImageProvider* getInstance();
+    QZXingImageProvider();
+    QImage requestImage(const QString &id, QSize *size, const QSize &requestedSize);
 };
 
 #endif // QZXINGIMAGEPROVIDER_H


### PR DESCRIPTION
This adds a better api for displaying images in QML.
To display an encoded qrcode from QML, we now can do:  
`Image { source: "image://QZXing/qrcode/<data>" }`

This allows different encoded images to be displayed simultaneously.

The `qrcode` part of the url is there to allow potential other future formats.
We could also maybe implement encoding options by doing for example `qrcode?errorCorrectionLevel=low` (this is not implemented in this PR).

The `image://QZXing/latestEncoded` url no longer works, but since the encoding is not working yet, I don't think people relied on that.

Support for requested size is still missing in the image provider. I changed the image provider to return a `QImage` instead of a `QPixmap`.

I changed `QZXing::encodeData` to be static, it didn't need to be a member function.

Closes #31