### PR TITLE
Add explicit namespace to byte class

### DIFF
--- a/src/zxing/zxing/common/DecoderResult.cpp
+++ b/src/zxing/zxing/common/DecoderResult.cpp
@@ -37,7 +37,7 @@ DecoderResult::DecoderResult(ArrayRef<byte> rawBytes,
                              Ref<String> text)
   : rawBytes_(rawBytes), text_(text),charSet_("") {}
 
-ArrayRef<byte> DecoderResult::getRawBytes() {
+ArrayRef<zxing::byte> DecoderResult::getRawBytes() {
   return rawBytes_;
 }
 


### PR DESCRIPTION
This avoids ambiguous compiler error.
Fixes #90.