### PR TITLE
src: use ::abs() instead of abs()

### DIFF
--- a/src/zxing/zxing/datamatrix/detector/DataMatrixDetector.cpp
+++ b/src/zxing/zxing/datamatrix/detector/DataMatrixDetector.cpp
@@ -357,7 +357,7 @@ Ref<ResultPointsAndTransitions> Detector::transitionsBetween(Ref<ResultPoint> fr
   int fromY = (int) from->getY();
   int toX = (int) to->getX();
   int toY = (int) to->getY();
-  bool steep = abs(toY - fromY) > abs(toX - fromX);
+  bool steep = ::abs(toY - fromY) > abs(toX - fromX);
   if (steep) {
     int temp = fromX;
     fromX = fromY;
@@ -367,8 +367,8 @@ Ref<ResultPointsAndTransitions> Detector::transitionsBetween(Ref<ResultPoint> fr
     toY = temp;
   }
 
-  int dx = abs(toX - fromX);
-  int dy = abs(toY - fromY);
+  int dx = ::abs(toX - fromX);
+  int dy = ::abs(toY - fromY);
   int error = -dx >> 1;
   int ystep = fromY < toY ? 1 : -1;
   int xstep = fromX < toX ? 1 : -1;

--- a/src/zxing/zxing/datamatrix/detector/DataMatrixDetector.cpp
+++ b/src/zxing/zxing/datamatrix/detector/DataMatrixDetector.cpp
@@ -357,7 +357,7 @@ Ref<ResultPointsAndTransitions> Detector::transitionsBetween(Ref<ResultPoint> fr
   int fromY = (int) from->getY();
   int toX = (int) to->getX();
   int toY = (int) to->getY();
-  bool steep = ::abs(toY - fromY) > abs(toX - fromX);
+  bool steep = ::abs(toY - fromY) > ::abs(toX - fromX);
   if (steep) {
     int temp = fromX;
     fromX = fromY;

--- a/src/zxing/zxing/qrcode/detector/QRAlignmentPatternFinder.cpp
+++ b/src/zxing/zxing/qrcode/detector/QRAlignmentPatternFinder.cpp
@@ -89,7 +89,7 @@ float AlignmentPatternFinder::crossCheckVertical(int startI, int centerJ, int ma
   }
 
   int stateCountTotal = stateCount[0] + stateCount[1] + stateCount[2];
-  if (5 * abs(stateCountTotal - originalStateCountTotal) >= 2 * originalStateCountTotal) {
+  if (5 * ::abs(stateCountTotal - originalStateCountTotal) >= 2 * originalStateCountTotal) {
     return nan();
   }
 

--- a/src/zxing/zxing/qrcode/detector/QRDetector.cpp
+++ b/src/zxing/zxing/qrcode/detector/QRDetector.cpp
@@ -242,7 +242,7 @@ float Detector::sizeOfBlackWhiteBlackRunBothWays(int fromX, int fromY, int toX, 
 float Detector::sizeOfBlackWhiteBlackRun(int fromX, int fromY, int toX, int toY) {
   // Mild variant of Bresenham's algorithm;
   // see http://en.wikipedia.org/wiki/Bresenham's_line_algorithm
-  bool steep = abs(toY - fromY) > abs(toX - fromX);
+  bool steep = ::abs(toY - fromY) > ::abs(toX - fromX);
   if (steep) {
     int temp = fromX;
     fromX = fromY;
@@ -252,8 +252,8 @@ float Detector::sizeOfBlackWhiteBlackRun(int fromX, int fromY, int toX, int toY)
     toY = temp;
   }
 
-  int dx = abs(toX - fromX);
-  int dy = abs(toY - fromY);
+  int dx = ::abs(toX - fromX);
+  int dy = ::abs(toY - fromY);
   int error = -dx >> 1;
   int xstep = fromX < toX ? 1 : -1;
   int ystep = fromY < toY ? 1 : -1;

--- a/src/zxing/zxing/qrcode/detector/QRFinderPatternFinder.cpp
+++ b/src/zxing/zxing/qrcode/detector/QRFinderPatternFinder.cpp
@@ -112,11 +112,11 @@ bool FinderPatternFinder::foundPatternCross(int* stateCount) {
   int moduleSize = (totalModuleSize << 8) / 7;
   int maxVariance = moduleSize / 2;
   // Allow less than 50% variance from 1-1-3-1-1 proportions
-  return abs(moduleSize - (stateCount[0] << 8)) < maxVariance && 
-         abs(moduleSize - (stateCount[1] << 8)) < maxVariance && 
-         abs(3.0f * moduleSize - (stateCount[2] << 8)) < 3 * maxVariance &&
-		 abs(moduleSize - (stateCount[3] << 8)) < maxVariance && 
-		 abs(moduleSize - (stateCount[4] << 8)) < maxVariance;
+  return ::abs(moduleSize - (stateCount[0] << 8)) < maxVariance &&
+         ::abs(moduleSize - (stateCount[1] << 8)) < maxVariance &&
+         ::abs(3.0f * moduleSize - (stateCount[2] << 8)) < 3 * maxVariance &&
+         ::abs(moduleSize - (stateCount[3] << 8)) < maxVariance &&
+         ::abs(moduleSize - (stateCount[4] << 8)) < maxVariance;
 }
 
 float FinderPatternFinder::crossCheckVertical(size_t startI, size_t centerJ, int maxCount, int originalStateCountTotal) {

--- a/src/zxing/zxing/qrcode/encoder/MaskUtil.cpp
+++ b/src/zxing/zxing/qrcode/encoder/MaskUtil.cpp
@@ -128,7 +128,7 @@ int MaskUtil::applyMaskPenaltyRule4(const ByteMatrix& matrix)
         }
     }
     int numTotalCells = int(matrix.getHeight() * matrix.getWidth());
-    int fivePercentVariances = abs(numDarkCells * 2 - numTotalCells) * 10 / numTotalCells;
+    int fivePercentVariances = ::abs(numDarkCells * 2 - numTotalCells) * 10 / numTotalCells;
     return fivePercentVariances * N4;
 }
 


### PR DESCRIPTION
Fix undefined reference errors while building with clang (Android).