### PR TITLE
Fix optional format in image provider

### DIFF
--- a/src/QZXingImageProvider.cpp
+++ b/src/QZXingImageProvider.cpp
@@ -38,14 +38,15 @@ QImage QZXingImageProvider::requestImage(const QString &id, QSize *size, const Q
         // it could not recognize the first key-value pair provided
         QUrlQuery optionQuery("options?dummy=&" + id.mid(customSettingsIndex + 1));
 
-        QString correctionLevelString = optionQuery.queryItemValue("corretionLevel");
-        QString formatString = optionQuery.queryItemValue("format");
-        if(formatString != "qrcode")
-        {
-            qWarning() << "Format not supported: " << formatString;
-            return QImage();
+        if (optionQuery.hasQueryItem("format")) {
+            QString formatString = optionQuery.queryItemValue("format");
+            if (formatString != "qrcode") {
+                qWarning() << "Format not supported: " << formatString;
+                return QImage();
+            }
         }
 
+        QString correctionLevelString = optionQuery.queryItemValue("corretionLevel");
         if(correctionLevelString == "H")
             correctionLevel = QZXing::EncodeErrorCorrectionLevel_H;
         else if(correctionLevelString == "Q")


### PR DESCRIPTION
From https://github.com/ftylitak/qzxing#qt-quick-1:

> optional custom settings that are passed like URL query parameters