### PR TITLE
Add border option to image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,11 @@ Image{
 
 Or use the encoding function with the optional custom settings that are passed like URL query parameters:
 
-| attribute name | value      | description                                   |
-| -------------- | ---------- | --------------------------------------------- |
-| corretionLevel | L, M, Q, H | the error correction level                    |
-| format         | qrcode     | the encode formatter. Currently only QR Code. |
+| attribute name | value       | description                                   |
+| -------------- | ----------- | --------------------------------------------- |
+| border         | true, false | whether the image has a border                |
+| corretionLevel | L, M, Q, H  | the error correction level                    |
+| format         | qrcode      | the encode formatter. Currently only QR Code. |
 
 the size of the image can be adjusted by using the Image.sourceWidth and Image.sourceHeight properties of Image QML element.
 

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -182,7 +182,8 @@ public slots:
     static QImage encodeData(const QString& data,
                              const EncoderFormat encoderFormat = EncoderFormat_QR_CODE,
                              const QSize encoderImageSize = QSize(240, 240),
-                             const EncodeErrorCorrectionLevel errorCorrectionLevel = EncodeErrorCorrectionLevel_L);
+                             const EncodeErrorCorrectionLevel errorCorrectionLevel = EncodeErrorCorrectionLevel_L,
+                             const bool border = false);
 
     /**
       * Get the prossecing time in millisecond of the last decode operation.

--- a/src/QZXingImageProvider.cpp
+++ b/src/QZXingImageProvider.cpp
@@ -27,6 +27,7 @@ QImage QZXingImageProvider::requestImage(const QString &id, QSize *size, const Q
     QString data;
     QZXing::EncoderFormat format = QZXing::EncoderFormat_QR_CODE;
     QZXing::EncodeErrorCorrectionLevel correctionLevel = QZXing::EncodeErrorCorrectionLevel_L;
+    bool border = false;
 
     int customSettingsIndex = id.lastIndexOf('?');
     if(customSettingsIndex >= 0)
@@ -55,12 +56,16 @@ QImage QZXingImageProvider::requestImage(const QString &id, QSize *size, const Q
             correctionLevel = QZXing::EncodeErrorCorrectionLevel_M;
         else if(correctionLevelString == "L")
             correctionLevel = QZXing::EncodeErrorCorrectionLevel_L;
+
+        if (optionQuery.hasQueryItem("border")) {
+            border = optionQuery.queryItemValue("border") == "true";
+        }
     } else
     {
         data = id.mid(slashIndex + 1);
     }
 
-    QImage result = QZXing::encodeData(data, format, requestedSize, correctionLevel);
+    QImage result = QZXing::encodeData(data, format, requestedSize, correctionLevel, border);
     *size = result.size();
     return result;
 }


### PR DESCRIPTION
This PR adds the `border=false|true` option to image provider. If `true` a white border with 1 pixel width is added to the image. By default no border is added.