### PR TITLE
Add transparent option to image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Or use the encoding function with the optional custom settings that are passed l
 | border          | true, false | image has border (white 1px)                  |
 | correctionLevel | L, M, Q, H  | the error correction level                    |
 | format          | qrcode      | the encode formatter. Currently only QR Code. |
+| transparent     | true, false | whether the black pixels are transparent      |
 
 the size of the image can be adjusted by using the Image.sourceWidth and Image.sourceHeight properties of Image QML element.
 

--- a/src/QZXing.cpp
+++ b/src/QZXing.cpp
@@ -576,13 +576,15 @@ QImage QZXing::encodeData(const QString& data,
                           const EncoderFormat encoderFormat,
                           const QSize encoderImageSize,
                           const EncodeErrorCorrectionLevel errorCorrectionLevel,
-                          const bool border)
+                          const bool border,
+                          const bool transparent)
 {
     return encodeData(data,
                       QZXingEncoderConfig(encoderFormat,
                                           encoderImageSize,
                                           errorCorrectionLevel,
-                                          border));
+                                          border,
+                                          transparent));
 }
 
 QImage QZXing::encodeData(const QString &data, const QZXingEncoderConfig &encoderConfig)
@@ -607,8 +609,8 @@ QImage QZXing::encodeData(const QString &data, const QZXingEncoderConfig &encode
             const std::vector< std::vector <zxing::byte> >& bytes = bytesRef->getArray();
             const int width = int(bytesRef->getWidth()) + (encoderConfig.border ? 2 : 0);
             const int height = int(bytesRef->getHeight()) + (encoderConfig.border ? 2 : 0);
-            const QRgb black = qRgb(0, 0, 0);
-            const QRgb white = qRgb(255, 255, 255);
+            const QRgb black = qRgba(0, 0, 0, encoderConfig.transparent ? 0 : 255);
+            const QRgb white = qRgba(255, 255, 255, 255);
 
             image = QImage(width, height, QImage::Format_ARGB32);
             image.fill(white);

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -190,7 +190,8 @@ public slots:
                              const EncoderFormat encoderFormat = EncoderFormat_QR_CODE,
                              const QSize encoderImageSize = QSize(240, 240),
                              const EncodeErrorCorrectionLevel errorCorrectionLevel = EncodeErrorCorrectionLevel_L,
-                             const bool border = false);
+                             const bool border = false,
+                             const bool transparent = false);
 
     /**
       * Get the prossecing time in millisecond of the last decode operation.
@@ -244,13 +245,15 @@ typedef struct QZXingEncoderConfig
     QSize imageSize;
     QZXing::EncodeErrorCorrectionLevel errorCorrectionLevel;
     bool border;
+    bool transparent;
 
     QZXingEncoderConfig(const QZXing::EncoderFormat encoderFormat_ = QZXing::EncoderFormat_QR_CODE,
                         const QSize encoderImageSize_ = QSize(240, 240),
                         const QZXing::EncodeErrorCorrectionLevel errorCorrectionLevel_ = QZXing::EncodeErrorCorrectionLevel_L,
-                        const bool border_ = false) :
+                        const bool border_ = false,
+                        const bool transparent_ = false) :
         format(encoderFormat_), imageSize(encoderImageSize_),
-        errorCorrectionLevel(errorCorrectionLevel_), border(border_) {}
+        errorCorrectionLevel(errorCorrectionLevel_), border(border_), transparent(transparent_) {}
 } QZXingEncoderConfig;
 
 #endif // QZXING_H

--- a/src/QZXingImageProvider.cpp
+++ b/src/QZXingImageProvider.cpp
@@ -29,6 +29,7 @@ QImage QZXingImageProvider::requestImage(const QString &id, QSize *size, const Q
     QZXing::EncoderFormat format = QZXing::EncoderFormat_QR_CODE;
     QZXing::EncodeErrorCorrectionLevel correctionLevel = QZXing::EncodeErrorCorrectionLevel_L;
     bool border = false;
+    bool transparent = false;
 
     int customSettingsIndex = id.lastIndexOf(QRegularExpression("\\?(correctionLevel|format|border)="));
     if(customSettingsIndex >= 0)
@@ -61,12 +62,16 @@ QImage QZXingImageProvider::requestImage(const QString &id, QSize *size, const Q
         if (optionQuery.hasQueryItem("border")) {
             border = QVariant(optionQuery.queryItemValue("border")).toBool();
         }
+
+        if (optionQuery.hasQueryItem("transparent")) {
+            transparent = optionQuery.queryItemValue("transparent") == "true";
+        }
     } else
     {
         data = id.mid(slashIndex + 1);
     }
 
-    QImage result = QZXing::encodeData(data, format, requestedSize, correctionLevel, border);
+    QImage result = QZXing::encodeData(data, format, requestedSize, correctionLevel, border, transparent);
     *size = result.size();
     return result;
 }


### PR DESCRIPTION
This PR adds the `transparent=false|true` option to image provider. If `true` the black pixels of the QR code are made transparent. By default the image is fully opaque.