### PR TITLE
Memory Leak Fix

### DIFF
--- a/src/QZXing.pri
+++ b/src/QZXing.pri
@@ -209,6 +209,7 @@ SOURCES += $$PWD/CameraImageWrapper.cpp \
     $$PWD/zxing/zxing/WriterException.cpp \
     $$PWD/zxing/zxing/aztec/AztecReader.cpp \
     $$PWD/zxing/zxing/aztec/AztecDetectorResult.cpp \
+    $$PWD/zxing/zxing/common/Counted.cpp \
     $$PWD/zxing/zxing/common/StringUtils.cpp \
     $$PWD/zxing/zxing/common/Str.cpp \
     $$PWD/zxing/zxing/common/PerspectiveTransform.cpp \

--- a/src/zxing/zxing/common/Counted.cpp
+++ b/src/zxing/zxing/common/Counted.cpp
@@ -1,0 +1,31 @@
+#include "Counted.h"
+
+namespace zxing {
+
+Counted::~Counted()
+{
+}
+
+Counted *Counted::retain()
+{
+    count_++;
+    return this;
+}
+
+void Counted::release()
+{
+    count_--;
+    if (count_ == 0) {
+      count_ = 0xDEADF001;
+      delete this;
+    }
+}
+
+int Counted::count() const
+{
+    return count_;
+}
+
+
+
+}

--- a/src/zxing/zxing/common/Counted.cpp
+++ b/src/zxing/zxing/common/Counted.cpp
@@ -2,6 +2,11 @@
 
 namespace zxing {
 
+Counted::Counted() :
+    count_(0)
+{
+}
+
 Counted::~Counted()
 {
 }

--- a/src/zxing/zxing/common/Counted.h
+++ b/src/zxing/zxing/common/Counted.h
@@ -27,9 +27,7 @@ class Counted {
 private:
   unsigned int count_;
 public:
-  Counted() :
-      count_(0) {
-  }
+  Counted();
 
   virtual ~Counted();
 

--- a/src/zxing/zxing/common/Counted.h
+++ b/src/zxing/zxing/common/Counted.h
@@ -30,25 +30,15 @@ public:
   Counted() :
       count_(0) {
   }
-  virtual ~Counted() {
-  }
-  Counted *retain() {
-    count_++;
-    return this;
-  }
-  void release() {
-    count_--;
-    if (count_ == 0) {
-      count_ = 0xDEADF001;
-      delete this;
-    }
-  }
 
+  virtual ~Counted();
+
+  Counted *retain();
+
+  void release();
 
   /* return the current count for denugging purposes or similar */
-  int count() const {
-    return count_;
-  }
+  int count() const;
 };
 
 /* counting reference to reference-counted objects */


### PR DESCRIPTION
 Fixing compiler warning: "Counted has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit"
This fixed especially a memory leak with a certain gcc version compiled in release mode (no problems in debug mode and with older gcc versions).
This could potentially fix #88 and #61.