### PR TITLE
Fix private include 

### DIFF
--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -18,7 +18,6 @@
 #define QZXING_H
 
 #include "QZXing_global.h"
-#include "zxing/ZXing.h"
 
 #include <QObject>
 #include <QImage>
@@ -102,10 +101,10 @@ public:
         EncodeErrorCorrectionLevel_H
     };
 
-    QZXing(QObject *parent = ZXING_NULLPTR);
+    QZXing(QObject *parent = nullptr);
     ~QZXing();
 
-    QZXing(DecoderFormat decodeHints, QObject *parent = ZXING_NULLPTR);
+    QZXing(DecoderFormat decodeHints, QObject *parent = nullptr);
 
 #ifdef QZXING_QML
 

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -101,10 +101,10 @@ public:
         EncodeErrorCorrectionLevel_H
     };
 
-    QZXing(QObject *parent = nullptr);
+    QZXing(QObject *parent = Q_NULLPTR);
     ~QZXing();
 
-    QZXing(DecoderFormat decodeHints, QObject *parent = nullptr);
+    QZXing(DecoderFormat decodeHints, QObject *parent = Q_NULLPTR);
 
 #ifdef QZXING_QML
 


### PR DESCRIPTION
I suggest using _private_ header in _public_ API is not a very good idea. External programs, using public API, couldn't find private header.