### PR TITLE
[fix] Fixed several warnings and use QElapsedTimer

### DIFF
--- a/src/QZXing.cpp
+++ b/src/QZXing.cpp
@@ -378,7 +378,7 @@ QRectF getTagRect(const ArrayRef<Ref<ResultPoint> > &resultPoints, const Ref<Bit
 
 QString QZXing::decodeImage(const QImage &image, int maxWidth, int maxHeight, bool smoothTransformation)
 {
-    QTime t;
+    QElapsedTimer t;
     t.start();
     processingTime = -1;
     Ref<Result> res;

--- a/src/QZXing.h
+++ b/src/QZXing.h
@@ -22,6 +22,7 @@
 #include <QObject>
 #include <QImage>
 #include <QVariantList>
+#include <QElapsedTimer>
 
 #include <set>
 

--- a/src/zxing/zxing/aztec/decoder/AztecDecoder.cpp
+++ b/src/zxing/zxing/aztec/decoder/AztecDecoder.cpp
@@ -69,47 +69,47 @@ namespace {
   const int NB_BITS_COMPACT[] = {
     0, 104, 240, 408, 608
   };
-        
+
   const int NB_BITS[] = {
     0, 128, 288, 480, 704, 960, 1248, 1568, 1920, 2304, 2720, 3168, 3648, 4160, 4704, 5280, 5888, 6528,
     7200, 7904, 8640, 9408, 10208, 11040, 11904, 12800, 13728, 14688, 15680, 16704, 17760, 18848, 19968
   };
-        
+
   const int NB_DATABLOCK_COMPACT[] = {
     0, 17, 40, 51, 76
   };
-        
+
   const int NB_DATABLOCK[] = {
     0, 21, 48, 60, 88, 120, 156, 196, 240, 230, 272, 316, 364, 416, 470, 528, 588, 652, 720, 790, 864,
     940, 1020, 920, 992, 1066, 1144, 1224, 1306, 1392, 1480, 1570, 1664
   };
-        
+
   const char* UPPER_TABLE[] = {
     "CTRL_PS", " ", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P",
     "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "CTRL_LL", "CTRL_ML", "CTRL_DL", "CTRL_BS"
   };
-        
+
   const char* LOWER_TABLE[] = {
     "CTRL_PS", " ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
     "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "CTRL_US", "CTRL_ML", "CTRL_DL", "CTRL_BS"
   };
-        
+
   const char* MIXED_TABLE[] = {
     "CTRL_PS", " ", "\1", "\2", "\3", "\4", "\5", "\6", "\7", "\b", "\t", "\n",
     "\13", "\f", "\r", "\33", "\34", "\35", "\36", "\37", "@", "\\", "^", "_",
     "`", "|", "~", "\177", "CTRL_LL", "CTRL_UL", "CTRL_PL", "CTRL_BS"
   };
-        
+
   const char* PUNCT_TABLE[] = {
     "", "\r", "\r\n", ". ", ", ", ": ", "!", "\"", "#", "$", "%", "&", "'", "(", ")",
     "*", "+", ",", "-", ".", "/", ":", ";", "<", "=", ">", "?", "[", "]", "{", "}", "CTRL_UL"
   };
-        
+
   const char* DIGIT_TABLE[] = {
     "CTRL_PS", " ", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ",", ".", "CTRL_UL", "CTRL_US"
   };
 }
-        
+
 Decoder::Table Decoder::getTable(char t) {
   switch (t) {
   case 'L':
@@ -127,7 +127,7 @@ Decoder::Table Decoder::getTable(char t) {
     return UPPER;
   }
 }
-        
+
 const char* Decoder::getCharacter(zxing::aztec::Decoder::Table table, int code) {
   switch (table) {
   case UPPER:
@@ -144,50 +144,50 @@ const char* Decoder::getCharacter(zxing::aztec::Decoder::Table table, int code) 
     return "";
   }
 }
-        
+
 Decoder::Decoder() {
   // nothing
 }
-        
+
 Ref<DecoderResult> Decoder::decode(Ref<zxing::aztec::AztecDetectorResult> detectorResult) {
   ddata_ = detectorResult;
-            
+
   // std::printf("getting bits\n");
-            
+
   Ref<BitMatrix> matrix = detectorResult->getBits();
-            
+
   if (!ddata_->isCompact()) {
     // std::printf("removing lines\n");
     matrix = removeDashedLines(ddata_->getBits());
   }
-            
+
   // std::printf("extracting bits\n");
   Ref<BitArray> rawbits = extractBits(matrix);
-            
+
   // std::printf("correcting bits\n");
   Ref<BitArray> aCorrectedBits = correctBits(rawbits);
-            
+
   // std::printf("decoding bits\n");
   Ref<String> result = getEncodedData(aCorrectedBits);
-            
+
   // std::printf("constructing array\n");
   ArrayRef<zxing::byte> arrayOut(aCorrectedBits->getSize());
-  for (int i = 0; i < aCorrectedBits->count(); i++) {
+  for (size_t i = 0; i < aCorrectedBits->count(); i++) {
     arrayOut[i] = (zxing::byte)aCorrectedBits->get(i);
   }
-            
+
   // std::printf("returning\n");
-            
+
   return Ref<DecoderResult>(new DecoderResult(arrayOut, result));
 }
-        
+
 Ref<String> Decoder::getEncodedData(Ref<zxing::BitArray> correctedBits) {
   int endIndex = codewordSize_ * ddata_->getNBDatablocks() - invertedBitCount_;
   if (endIndex > (int)correctedBits->getSize()) {
     // std::printf("invalid input\n");
     throw FormatException("invalid input data");
   }
-            
+
   Table lastTable = UPPER;
   Table table = UPPER;
   int startIndex = 0;
@@ -196,29 +196,29 @@ Ref<String> Decoder::getEncodedData(Ref<zxing::BitArray> correctedBits) {
   bool shift = false;
   bool switchShift = false;
   bool binaryShift = false;
-            
+
   while (!end) {
     // std::printf("decoooooding\n");
-                
+
     if (shift) {
       switchShift = true;
     } else {
       lastTable = table;
     }
-                
+
     int code;
     if (binaryShift) {
       if (endIndex - startIndex < 5) {
         break;
       }
-                    
+
       int length = readCode(correctedBits, startIndex, 5);
       startIndex += 5;
       if (length == 0) {
         if (endIndex - startIndex < 11) {
           break;
         }
-                        
+
         length = readCode(correctedBits, startIndex, 11) + 31;
         startIndex += 11;
       }
@@ -227,7 +227,7 @@ Ref<String> Decoder::getEncodedData(Ref<zxing::BitArray> correctedBits) {
           end = true;
           break;
         }
-                        
+
         code = readCode(correctedBits, startIndex, 8);
         add(result, code);
         startIndex += 8;
@@ -240,27 +240,27 @@ Ref<String> Decoder::getEncodedData(Ref<zxing::BitArray> correctedBits) {
         }
         code = readCode(correctedBits, startIndex, 8);
         startIndex += 8;
-                        
+
         add(result, code);
       } else {
         int size = 5;
-                        
+
         if (table == DIGIT) {
           size = 4;
         }
-                        
+
         if (endIndex - startIndex < size) {
           break;
         }
-                        
+
         code = readCode(correctedBits, startIndex, size);
         startIndex += size;
-                        
+
         const char *str = getCharacter(table, code);
         std::string string(str);
         if ((int)string.find("CTRL_") != -1) {
           table = getTable(str[5]);
-                            
+
           if (str[6] == 'S') {
             shift = true;
             if (str[5] == 'B') {
@@ -270,29 +270,29 @@ Ref<String> Decoder::getEncodedData(Ref<zxing::BitArray> correctedBits) {
         } else {
           result.append(string);
         }
-                        
+
       }
     }
-                
+
     if (switchShift) {
       table = lastTable;
       shift = false;
       switchShift = false;
     }
-                
-                
+
+
   }
-            
+
   return Ref<String>(new String(result));
-            
+
 }
-        
+
 Ref<BitArray> Decoder::correctBits(Ref<zxing::BitArray> rawbits) {
   //return rawbits;
   // std::printf("decoding stuff:%d datablocks in %d layers\n", ddata_->getNBDatablocks(), ddata_->getNBLayers());
-            
+
   Ref<GenericGF> gf = GenericGF::AZTEC_DATA_6;
-            
+
   if (ddata_->getNBLayers() <= 2) {
     codewordSize_ = 6;
     gf = GenericGF::AZTEC_DATA_6;
@@ -306,11 +306,11 @@ Ref<BitArray> Decoder::correctBits(Ref<zxing::BitArray> rawbits) {
     codewordSize_ = 12;
     gf = GenericGF::AZTEC_DATA_12;
   }
-            
+
   int numDataCodewords = ddata_->getNBDatablocks();
   int numECCodewords;
   int offset;
-            
+
   if (ddata_->isCompact()) {
     offset = NB_BITS_COMPACT[ddata_->getNBLayers()] - numCodewords_ * codewordSize_;
     numECCodewords = NB_DATABLOCK_COMPACT[ddata_->getNBLayers()] - numDataCodewords;
@@ -318,9 +318,9 @@ Ref<BitArray> Decoder::correctBits(Ref<zxing::BitArray> rawbits) {
     offset = NB_BITS[ddata_->getNBLayers()] - numCodewords_ * codewordSize_;
     numECCodewords = NB_DATABLOCK[ddata_->getNBLayers()] - numDataCodewords;
   }
-            
+
   ArrayRef<int> dataWords(numCodewords_);
-            
+
   for (int i = 0; i < numCodewords_; i++) {
     int flag = 1;
     for (int j = 1; j <= codewordSize_; j++) {
@@ -329,12 +329,12 @@ Ref<BitArray> Decoder::correctBits(Ref<zxing::BitArray> rawbits) {
       }
       flag <<= 1;
     }
-                
+
     //
     //
     //
   }
-            
+
   try {
     ReedSolomonDecoder rsDecoder(gf);
     rsDecoder.decode(dataWords, numECCodewords);
@@ -346,56 +346,56 @@ Ref<BitArray> Decoder::correctBits(Ref<zxing::BitArray> rawbits) {
     (void)iae;
     // std::printf("illegal argument exception: %s", iae.what());
   }
-            
+
   offset = 0;
   invertedBitCount_ = 0;
-            
+
   Ref<BitArray> correctedBits(new BitArray(numDataCodewords * codewordSize_));
   for (int i = 0; i < numDataCodewords; i++) {
-                
+
     bool seriesColor = false;
     int seriesCount = 0;
     int flag = 1 << (codewordSize_ - 1);
-                
+
     for (int j = 0; j < codewordSize_; j++) {
-                    
+
       bool color = (dataWords[i] & flag) == flag;
-                    
+
       if (seriesCount == codewordSize_ - 1) {
-                        
+
         if (color == seriesColor) {
           throw FormatException("bit was not inverted");
         }
-                        
+
         seriesColor = false;
         seriesCount = 0;
         offset++;
         invertedBitCount_++;
-                        
+
       } else {
-                        
+
         if (seriesColor == color) {
           seriesCount++;
         } else {
           seriesCount = 1;
           seriesColor = color;
         }
-                        
+
         if (color) correctedBits->set(i * codewordSize_ + j - offset);
-                        
+
       }
-                    
+
       flag = ((unsigned int)flag) >> 1;
-                    
+
     }
   }
-            
+
   return correctedBits;
 }
-        
+
 Ref<BitArray> Decoder::extractBits(Ref<zxing::BitMatrix> matrix) {
   std::vector<bool> rawbits;
-            
+
   if (ddata_->isCompact()) {
     if (ddata_->getNBLayers() > 5) { //NB_BITS_COMPACT length
       throw FormatException("data is too long");
@@ -409,22 +409,22 @@ Ref<BitArray> Decoder::extractBits(Ref<zxing::BitMatrix> matrix) {
     rawbits = std::vector<bool>(NB_BITS[ddata_->getNBLayers()]);
     numCodewords_ = NB_DATABLOCK[ddata_->getNBLayers()];
   }
-            
+
   int layer = ddata_->getNBLayers();
   int size = matrix->getHeight();
   int rawbitsOffset = 0;
   int matrixOffset = 0;
-            
+
 
   while (layer != 0) {
-                
+
     int flip = 0;
     for (int i = 0; i < 2 * size - 4; i++) {
       rawbits[rawbitsOffset + i] = matrix->get(matrixOffset + flip, matrixOffset + i / 2);
       rawbits[rawbitsOffset + 2 * size - 4 + i] = matrix->get(matrixOffset + i / 2, matrixOffset + size - 1 - flip);
       flip = (flip + 1) % 2;
     }
-                
+
     flip = 0;
     for (int i = 2 * size + 1; i > 5; i--) {
       rawbits[rawbitsOffset + 4 * size - 8 + (2 * size - i) + 1] =
@@ -433,63 +433,63 @@ Ref<BitArray> Decoder::extractBits(Ref<zxing::BitMatrix> matrix) {
         matrix->get(matrixOffset + i / 2 - 1, matrixOffset + flip);
       flip = (flip + 1) % 2;
     }
-                
+
     matrixOffset += 2;
     rawbitsOffset += 8 * size - 16;
     layer--;
     size -= 4;
-                
+
   }
-            
+
   Ref<BitArray> returnValue(new BitArray(int(rawbits.size())));
   for (int i = 0; i < (int)rawbits.size(); i++) {
     if (rawbits[i]) returnValue->set(i);
   }
-            
+
   return returnValue;
-            
+
 }
-        
+
 Ref<BitMatrix> Decoder::removeDashedLines(Ref<zxing::BitMatrix> matrix) {
   int nbDashed = 1 + 2 * ((matrix->getWidth() - 1) / 2 / 16);
   Ref<BitMatrix> newMatrix(new BitMatrix(matrix->getWidth() - nbDashed, matrix->getHeight() - nbDashed));
-            
+
   int nx = 0;
-            
+
   for (int x = 0; x < (int)matrix->getWidth(); x++) {
-                
+
     if ((matrix->getWidth() / 2 - x) % 16 == 0) {
       continue;
     }
-                
+
     int ny = 0;
     for (int y = 0; y < (int)matrix->getHeight(); y++) {
-                    
+
       if ((matrix->getWidth() / 2 - y) % 16 == 0) {
         continue;
       }
-                    
+
       if (matrix->get(x, y)) {
         newMatrix->set(nx, ny);
       }
       ny++;
-                    
+
     }
     nx++;
-                
+
   }
   return newMatrix;
 }
-        
+
 int Decoder::readCode(Ref<zxing::BitArray> rawbits, int startIndex, int length) {
   int res = 0;
-            
+
   for (int i = startIndex; i < startIndex + length; i++) {
     res <<= 1;
     if (rawbits->get(i)) {
       res ++;
     }
   }
-            
+
   return res;
 }

--- a/src/zxing/zxing/common/GridSampler.cpp
+++ b/src/zxing/zxing/common/GridSampler.cpp
@@ -34,7 +34,7 @@ GridSampler::GridSampler() {
 
 Ref<BitMatrix> GridSampler::sampleGrid(Ref<BitMatrix> image, int dimension, Ref<PerspectiveTransform> transform) {
   Ref<BitMatrix> bits(new BitMatrix(dimension));
-  vector<float> points(dimension << 1, (const float)0.0f);
+  vector<float> points(dimension << 1, 0.0f);
   for (int y = 0; y < dimension; y++) {
     int max = int(points.size());
     float yValue = (float)y + 0.5f;
@@ -55,7 +55,7 @@ Ref<BitMatrix> GridSampler::sampleGrid(Ref<BitMatrix> image, int dimension, Ref<
 
 Ref<BitMatrix> GridSampler::sampleGrid(Ref<BitMatrix> image, int dimensionX, int dimensionY, Ref<PerspectiveTransform> transform) {
   Ref<BitMatrix> bits(new BitMatrix(dimensionX, dimensionY));
-  vector<float> points(dimensionX << 1, (const float)0.0f);
+  vector<float> points(dimensionX << 1, 0.0f);
   for (int y = 0; y < dimensionY; y++) {
     int max = int(points.size());
     float yValue = (float)y + 0.5f;

--- a/src/zxing/zxing/common/reedsolomon/GenericGF.cpp
+++ b/src/zxing/zxing/common/reedsolomon/GenericGF.cpp
@@ -36,11 +36,11 @@ Ref<GenericGF> GenericGF::QR_CODE_FIELD_256(new GenericGF(0x011D, 256, 0));
 Ref<GenericGF> GenericGF::DATA_MATRIX_FIELD_256(new GenericGF(0x012D, 256, 1));
 Ref<GenericGF> GenericGF::AZTEC_DATA_8 = DATA_MATRIX_FIELD_256;
 Ref<GenericGF> GenericGF::MAXICODE_FIELD_64 = AZTEC_DATA_6;
-  
+
 namespace {
   size_t INITIALIZATION_THRESHOLD = 0;
 }
-  
+
 GenericGF::GenericGF(int primitive_, size_t size_, int b)
   : size(size_), primitive(primitive_), generatorBase(b), initialized(false) {
   if (size <= INITIALIZATION_THRESHOLD) {
@@ -56,9 +56,9 @@ GenericGF::~GenericGF()
 void GenericGF::initialize() {
   expTable = std::vector<int>(size);
   logTable = std::vector<int>(size);
-    
-  int x = 1;
-    
+
+  size_t x = 1;
+
   for (size_t i = 0; i < size; i++) {
     expTable[i] = x;
     x <<= 1; // x = x * 2; we're assuming the generator alpha is 2
@@ -81,26 +81,26 @@ void GenericGF::initialize() {
   one = Ref<GenericGFPoly>(new GenericGFPoly(this, coefficients_one));
   initialized = true;
 }
-  
+
 void GenericGF::checkInit() {
   if (!initialized) {
     initialize();
   }
 }
-  
+
 Ref<GenericGFPoly> GenericGF::getZero() {
   checkInit();
   return zero;
 }
-  
+
 Ref<GenericGFPoly> GenericGF::getOne() {
   checkInit();
   return one;
 }
-  
+
 Ref<GenericGFPoly> GenericGF::buildMonomial(int degree, int coefficient) {
   checkInit();
-    
+
   if (degree < 0) {
     throw IllegalArgumentException("Degree must be non-negative");
   }
@@ -109,19 +109,19 @@ Ref<GenericGFPoly> GenericGF::buildMonomial(int degree, int coefficient) {
   }
   ArrayRef<int> coefficients(degree + 1);
   coefficients[0] = coefficient;
-    
+
   return Ref<GenericGFPoly>(new GenericGFPoly(this, coefficients));
 }
-  
+
 int GenericGF::addOrSubtract(int a, int b) {
   return a ^ b;
 }
-  
+
 int GenericGF::exp(int a) {
   checkInit();
   return expTable[a];
 }
-  
+
 int GenericGF::log(int a) {
   checkInit();
   if (a == 0) {
@@ -129,7 +129,7 @@ int GenericGF::log(int a) {
   }
   return logTable[a];
 }
-  
+
 int GenericGF::inverse(int a) {
   checkInit();
   if (a == 0) {
@@ -137,17 +137,17 @@ int GenericGF::inverse(int a) {
   }
   return expTable[size - logTable[a] - 1];
 }
-  
+
 int GenericGF::multiply(int a, int b) {
   checkInit();
-    
+
   if (a == 0 || b == 0) {
     return 0;
   }
-    
+
   return expTable[(logTable[a] + logTable[b]) % (size - 1)];
   }
-    
+
 size_t GenericGF::getSize() {
   return size;
 }

--- a/src/zxing/zxing/common/reedsolomon/ReedSolomonDecoder.cpp
+++ b/src/zxing/zxing/common/reedsolomon/ReedSolomonDecoder.cpp
@@ -138,7 +138,7 @@ ArrayRef<int> ReedSolomonDecoder::findErrorLocations(Ref<GenericGFPoly> errorLoc
   }
   ArrayRef<int> result(new Array<int>(numErrors));
   int e = 0;
-  for (int i = 1; i < field->getSize() && e < numErrors; i++) {
+  for (size_t i = 1; i < field->getSize() && e < numErrors; i++) {
     if (errorLocator->evaluateAt(i) == 0) {
       result[e] = field->inverse(i);
       e++;

--- a/src/zxing/zxing/common/reedsolomon/ReedSolomonEncoder.cpp
+++ b/src/zxing/zxing/common/reedsolomon/ReedSolomonEncoder.cpp
@@ -51,7 +51,7 @@ void ReedSolomonEncoder::encode(std::vector<zxing::byte> &toEncode, int ecBytes)
     ArrayRef<int> infoCoefficients(dataBytes);
 
     //to-do optimize the following loop
-    for(size_t i=0; i< dataBytes; i++)
+    for(auto i=0; i< dataBytes; i++)
         infoCoefficients[i] = toEncode[size_t(i)];
 
     Ref<GenericGFPoly> info(new GenericGFPoly(field_, infoCoefficients));

--- a/src/zxing/zxing/common/reedsolomon/ReedSolomonEncoder.cpp
+++ b/src/zxing/zxing/common/reedsolomon/ReedSolomonEncoder.cpp
@@ -51,7 +51,7 @@ void ReedSolomonEncoder::encode(std::vector<zxing::byte> &toEncode, int ecBytes)
     ArrayRef<int> infoCoefficients(dataBytes);
 
     //to-do optimize the following loop
-    for(auto i=0; i< dataBytes; i++)
+    for(int i=0; i< dataBytes; i++)
         infoCoefficients[i] = toEncode[size_t(i)];
 
     Ref<GenericGFPoly> info(new GenericGFPoly(field_, infoCoefficients));

--- a/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
+++ b/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
@@ -161,11 +161,11 @@ int Encoder::getAlphanumericCode(int code)
    */
 Mode Encoder::chooseMode(const std::wstring& content, const std::string& encoding)
 {
-    if (encoding == "Shift_JIS") 
-	{
+    if (encoding == "Shift_JIS")
+    {
         std::cout << "DEBUG: Shift_JIS detected...be aware!" << std::endl;
         return Mode::BYTE;
-	}
+    }
 
     bool hasNumeric = false;
     bool hasAlphanumeric = false;
@@ -542,7 +542,7 @@ void Encoder::append8BitBytes(const std::wstring& content, BitArray& bits, const
     QString str = QString::fromStdWString(content);
     QByteArray array = str.toUtf8();
 
-    for (size_t i=0; i<array.size(); i++) {
+    for (auto i=0; i<array.size(); i++) {
         bits.appendBits(array.at(i), 8);
     }
 }

--- a/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
+++ b/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
@@ -542,7 +542,7 @@ void Encoder::append8BitBytes(const std::wstring& content, BitArray& bits, const
     QString str = QString::fromStdWString(content);
     QByteArray array = str.toUtf8();
 
-    for (auto i=0; i<array.size(); i++) {
+    for (int i=0; i<array.size(); i++) {
         bits.appendBits(array.at(i), 8);
     }
 }


### PR DESCRIPTION
Since Qt 5.14 is out, several QTime APIs are marked as deprecated, this PR is to resolve those warnings and added some type fixes (like between `size_t` and `int`).