### PR TITLE
Fix some static analyzer warnings

### DIFF
--- a/src/zxing/zxing/datamatrix/decoder/DataMatrixDecodedBitStreamParser.cpp
+++ b/src/zxing/zxing/datamatrix/decoder/DataMatrixDecodedBitStreamParser.cpp
@@ -404,6 +404,7 @@ void DecodedBitStreamParser::decodeBase256Segment(Ref<BitSource> bits, ostringst
     // Have seen this particular error in the wild, such as at
     // http://www.bcgen.com/demo/IDAutomationStreamingDataMatrix.aspx?MODE=3&D=Fred&PFMT=3&PT=F&X=0.3&O=0&LM=0.2
     if (bits->available() < 8) {
+      delete [] bytes;
       throw FormatException("byteSegments");
     }
     bytes[i] = unrandomize255State(bits->readBits(8), codewordPosition++);

--- a/src/zxing/zxing/oned/UPCEANReader.cpp
+++ b/src/zxing/zxing/oned/UPCEANReader.cpp
@@ -48,13 +48,11 @@ namespace {
    * Start/end guard pattern.
    */
   const int START_END_PATTERN_[] = {1, 1, 1};
-  const int START_END_PATTERN_LEN = LEN(START_END_PATTERN_);
 
   /**
    * Pattern marking the middle of a UPC/EAN pattern, separating the two halves.
    */
   const int MIDDLE_PATTERN_[] = {1, 1, 1, 1, 1};
-  const int MIDDLE_PATTERN_LEN = LEN(MIDDLE_PATTERN_);
 
   /**
    * "Odd", or "L" patterns used to encode UPC/EAN digits.
@@ -71,7 +69,6 @@ namespace {
     {1, 2, 1, 3}, // 8
     {3, 1, 1, 2}  // 9
   };
-  const int L_PATTERNS_LEN = LEN(L_PATTERNS_);
 
   /**
    * As above but also including the "even", or "G" patterns used to encode UPC/EAN digits.
@@ -98,7 +95,6 @@ namespace {
     {3, 1, 2, 1}, // 18 reversed 8
     {2, 1, 1, 3}  // 19 reversed 9
   };
-  const int L_AND_G_PATTERNS_LEN = LEN(L_AND_G_PATTERNS_);
 }
 
 const int UPCEANReader::MAX_AVG_VARIANCE = (int)(PATTERN_MATCH_RESULT_SCALE_FACTOR * 0.48f);

--- a/src/zxing/zxing/oned/rss/RSS14Reader.cpp
+++ b/src/zxing/zxing/oned/rss/RSS14Reader.cpp
@@ -47,9 +47,9 @@ Ref<Result> RSS14Reader::decodeRow(int rowNumber, Ref<BitArray> row, DecodeHints
     addOrTally(m_possibleRightPairs, rightPair);
     row->reverse();
 
-    for (Pair left : m_possibleLeftPairs) {
+    for (Pair &left : m_possibleLeftPairs) {
         if (left.getCount() > 1) {
-            for (Pair right : m_possibleRightPairs) {
+            for (Pair &right : m_possibleRightPairs) {
                 if (right.getCount() > 1 && checkChecksum(left, right)) {
                     return constructResult(left, right);
                 }

--- a/src/zxing/zxing/oned/rss/expanded/ExpandedRow.cpp
+++ b/src/zxing/zxing/oned/rss/expanded/ExpandedRow.cpp
@@ -47,7 +47,7 @@ bool ExpandedRow::isEquivalent(std::vector<ExpandedPair> otherPairs) const
 String ExpandedRow::toString()
 {
     String result("{ ");
-    for (auto i : m_pairs) {
+    for (const auto &i : m_pairs) {
         result.append(i.toString().getText());
     }
     result.append(" }");

--- a/src/zxing/zxing/oned/rss/expanded/RSSExpandedReader.cpp
+++ b/src/zxing/zxing/oned/rss/expanded/RSSExpandedReader.cpp
@@ -263,9 +263,9 @@ void RSSExpandedReader::removePartialRows()
     for (size_t i = 0; i < m_rows.size(); i++) {
         if (m_rows[i].getPairs().size() != m_pairs.size()) {
             bool allFound = true;
-            for (ExpandedPair p : m_rows[i].getPairs()) {
+            for (ExpandedPair &p : m_rows[i].getPairs()) {
                 bool found = false;
-                for (ExpandedPair pp : m_pairs) {
+                for (ExpandedPair &pp : m_pairs) {
                     if (p.equals(pp))
                     {
                         found = true;
@@ -290,9 +290,9 @@ bool RSSExpandedReader::isPartialRow(std::vector<ExpandedPair>& pairs, std::vect
 {
     for (ExpandedRow r : rows) {
         bool allFound = true;
-        for (ExpandedPair p : pairs) {
+        for (ExpandedPair &p : pairs) {
             bool found = false;
-            for (ExpandedPair pp : r.getPairs()) {
+            for (ExpandedPair &pp : r.getPairs()) {
                 if (p.equals(pp)) {
                     found = true;
                     break;

--- a/src/zxing/zxing/oned/rss/expanded/decoders/GeneralAppIdDecoder.cpp
+++ b/src/zxing/zxing/oned/rss/expanded/decoders/GeneralAppIdDecoder.cpp
@@ -394,7 +394,10 @@ DecodedChar GeneralAppIdDecoder::decodeAlphanumeric(int pos)
         c = '/';
         break;
     default:
-        throw IllegalStateException("Decoding invalid alphanumeric value: " + sixBitValue);
+    {
+        auto msg = "Decoding invalid alphanumeric value: " + std::to_string(sixBitValue);
+        throw IllegalStateException(msg.c_str());
+    }
     }
     return DecodedChar(pos + 6, c);
 }

--- a/src/zxing/zxing/qrcode/decoder/QRDecodedBitStreamParser.cpp
+++ b/src/zxing/zxing/qrcode/decoder/QRDecodedBitStreamParser.cpp
@@ -229,6 +229,7 @@ void DecodedBitStreamParser::decodeNumericSegment(Ref<BitSource> bits, std::stri
     while (count >= 3) {
         // Each 10 bits encodes three digits
         if (bits->available() < 10) {
+            delete[] bytes;
             throw ReaderException("format exception");
         }
         int threeDigitsBits = bits->readBits(10);

--- a/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
+++ b/src/zxing/zxing/qrcode/encoder/QREncoder.cpp
@@ -416,6 +416,7 @@ BitArray* Encoder::interleaveWithECBytes(const BitArray& bits,
         message += " and ";
         message += zxing::common::StringUtils::intToStr(result->getSizeInBytes());
         message += " differ.";
+        delete result;
         throw WriterException(message.c_str());
     }
 


### PR DESCRIPTION
`clazy` and `clang-tidy` were used to check code. Some things are not fixed yet: the require thorough investigation.