### PR TITLE
Fix names of headers files in !symbian scope

### DIFF
--- a/src/QZXing-components.pri
+++ b/src/QZXing-components.pri
@@ -449,9 +449,9 @@ symbian {
 !symbian {
     isEmpty(PREFIX) {
         maemo5 {
-            target.path = /opt/usr/lib
+            PREFIX = /opt/usr
         } else {
-            target.path = /usr/lib
+            PREFIX = /usr
         }
     }
 

--- a/src/QZXing-components.pri
+++ b/src/QZXing-components.pri
@@ -458,7 +458,7 @@ symbian {
     DEFINES += NOFMAXL
 
 	# Installation
-	headers.files = qzxing.h QZXing_global.h
+	headers.files = $$PWD/QZXing.h $$PWD/QZXing_global.h
 	headers.path = $$PREFIX/include
 	target.path = $$PREFIX/lib
 	INSTALLS += headers target


### PR DESCRIPTION
Without this fix I can't deploy project to the remote device.

`11:38:50: Local file "{build directory}/qzxing.h" does not exist.`
`11:38:50: Deploy step failed.`