### PR TITLE
Properly exported the defines for CMake users

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,10 @@ if(WIN32)
     add_definitions(-DNO_ICONV)
 endif(WIN32)
 
+if(ANDROID)
+    add_definitions(-DNO_ICONV)
+endif()
+
 if(VS_WINRT_COMPONENT)
     add_definitions(-DNO_ICONV)
 endif(VS_WINRT_COMPONENT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,10 @@ if(QZXING_USE_QML)
     add_definitions(-DQZXING_QML)
 endif(QZXING_USE_QML)
 
+if(QZXING_USE_ENCODER)
+    add_definitions(-DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
+endif(QZXING_USE_ENCODER)
+
 add_library(qzxing "" ${SOURCES})
 
 if(WIN32)
@@ -61,6 +65,7 @@ target_link_libraries(qzxing Qt5::Core Qt5::Gui)
 
 if(QZXING_MULTIMEDIA)
     target_link_libraries(qzxing Qt5::Multimedia)
+    target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
@@ -68,7 +73,12 @@ if(QZXING_USE_QML)
         Qt5::Svg
         Qt5::Quick
         Qt5::QuickControls2)
+    target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
+
+if(QZXING_USE_ENCODER)
+    target_compile_definitions(qzxing PUBLIC -DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
+endif(QZXING_USE_ENCODER)
 
 # Change Global Definitions depending on how you want to use the library
 target_compile_definitions(qzxing PUBLIC DISABLE_LIBRARY_FEATURES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,31 @@ if(QZXING_USE_ENCODER)
     target_compile_definitions(qzxing PUBLIC -DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
 endif(QZXING_USE_ENCODER)
 
+if(QZXING_USE_DECODER_QR_CODE)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_QR_CODE)
+endif()
+
+if(QZXING_USE_DECODER_1D_BARCODES)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_1D_BARCODES)
+endif()
+
+if(QZXING_USE_DECODER_DATA_MATRIX)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_DATA_MATRIX)
+endif()
+
+if(QZXING_USE_DECODER_AZTEC)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_AZTEC)
+endif()
+
+if(QZXING_USE_DECODER_PDF17)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_PDF17)
+endif()
+
+if(QZXING_USE_DECODER_1D_BARCODES)
+    target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_1D_BARCODES)
+endif()
+
+
 # Change Global Definitions depending on how you want to use the library
 target_compile_definitions(qzxing PUBLIC DISABLE_LIBRARY_FEATURES)
 


### PR DESCRIPTION
- CMake users can now use QZXING_USE_ENCODER to enable QR code encoding
- definitions are export correctly for including projects
- CMake users no longer have to manually add the definitions into src/CMakeLists.txt