### PR TITLE
QZXingFilter orientation support

### DIFF
--- a/examples/QZXingLive/main.qml
+++ b/examples/QZXingLive/main.qml
@@ -85,6 +85,7 @@ ApplicationWindow
     QZXingFilter
     {
         id: zxingFilter
+        orientation: videoOutput.orientation
         captureRect: {
             // setup bindings
             videoOutput.contentRect;

--- a/src/QZXingFilter.cpp
+++ b/src/QZXingFilter.cpp
@@ -393,12 +393,11 @@ void QZXingFilterRunnable::processVideoFrameProbed(SimpleVideoFrame & videoFrame
     if (!orientation) {
         decode(*image_ptr);
     } else {
-        QImage translatedImage = image_ptr->transformed([](QPoint center, int orientation) {
-                QMatrix matrix;
-                matrix.translate(center.x(), center.y());
-                matrix.rotate(-orientation);
-                return matrix;
-        } (image_ptr->rect().center(), orientation));
+        QTransform transformation;
+        transformation.translate(image_ptr->rect().center().x(), image_ptr->rect().center().y());
+        transformation.rotate(-orientation);
+
+        QImage translatedImage = image_ptr->transformed(transformation);
 
         decode(translatedImage);
     }

--- a/src/QZXingFilter.h
+++ b/src/QZXingFilter.h
@@ -75,16 +75,20 @@ class QZXingFilter : public QAbstractVideoFilter
         Q_PROPERTY(bool decoding READ isDecoding NOTIFY isDecodingChanged)
         Q_PROPERTY(QZXing* decoder READ getDecoder)
         Q_PROPERTY(QRectF captureRect MEMBER captureRect NOTIFY captureRectChanged)
+        Q_PROPERTY(int orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
 
     signals:
         void isDecodingChanged();
         void decodingFinished(bool succeeded, int decodeTime);
         void decodingStarted();
         void captureRectChanged();
+        void orientationChanged(int orientation);
 
     private slots:
         void handleDecodingStarted();
         void handleDecodingFinished(bool succeeded);
+        void setOrientation(int orientation);
+        int orientation() const;
 
     private: /// Attributes
         QZXing decoder;
@@ -93,6 +97,7 @@ class QZXingFilter : public QAbstractVideoFilter
 
         SimpleVideoFrame frame;
         QFuture<void> processThread;
+        int orientation_;
 
     public:  /// Methods
         explicit QZXingFilter(QObject *parent = 0);


### PR DESCRIPTION
Add support to QZXingFilter orientation respect. Each frame, before it is decoded, it is first rotated based on the orientation info (if needed).

Thanks to @Eism for making the code suggestion, @DenPonomarchuk and @MichaelSavchenko67 for bringing the issue back to the foreground and testing it.

resolves #204 and #120 