### PR TITLE
Fix build with cmake (qt6)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,9 @@ add_subdirectory(zxing/zxing)
 
 target_link_libraries(qzxing Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui)
 
-if(QZXING_MULTIMEDIA)
+if(QZXING_MULTIMEDIA)    
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Multimedia REQUIRED)
+
     target_link_libraries(qzxing Qt${QT_VERSION_MAJOR}::Multimedia)
     target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.2)
 project(QZXing)
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt5 COMPONENTS Gui REQUIRED)
-find_package(Qt5 COMPONENTS Multimedia )
-find_package(Qt5 REQUIRED Svg Quick QuickControls2)
+
+
+if (NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Svg Quick QuickControls2 REQUIRED)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Svg Quick QuickControls2 REQUIRED)
+
 
 SET(BIGINT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxing/bigint)
 SET(WIN32_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/win32/zxing)
@@ -65,18 +69,18 @@ add_subdirectory(zxing/bigint)
 
 add_subdirectory(zxing/zxing)
 
-target_link_libraries(qzxing Qt5::Core Qt5::Gui)
+target_link_libraries(qzxing Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui)
 
 if(QZXING_MULTIMEDIA)
-    target_link_libraries(qzxing Qt5::Multimedia)
+    target_link_libraries(qzxing Qt${QT_VERSION_MAJOR}::Multimedia)
     target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
     target_link_libraries(qzxing
-        Qt5::Svg
-        Qt5::Quick
-        Qt5::QuickControls2)
+        Qt${QT_VERSION_MAJOR}::Svg
+        Qt${QT_VERSION_MAJOR}::Quick
+        Qt${QT_VERSION_MAJOR}::QuickControls2)
     target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
 


### PR DESCRIPTION
Add support qt6 library for CMake build system. 

## Search order of qt libraries 

* If the **QT_VERSION_MAJOR** variable not defined then CMake try find Qt6.
* If Qt6 is not exists the CMake try search qt5.

If you have two qt version on one machine you can force sets QT_VERSION_MAJOR for build 