### PR TITLE
src: Support Ubuntu Touch in QZXingFilter

### DIFF
--- a/src/QZXing-components.pri
+++ b/src/QZXing-components.pri
@@ -450,6 +450,10 @@ unix {
 
     DEFINES += NOFMAXL
 
+    contains( CONFIG, ubports) {
+        DEFINES += Q_OS_UBUNTUTOUCH
+    }
+
     contains( CONFIG, sailfishapp) {
         DEFINES += Q_OS_SAILFISH
     } else {

--- a/src/QZXingFilter.cpp
+++ b/src/QZXingFilter.cpp
@@ -196,7 +196,7 @@ static QImage* rgbDataToGrayscale(const uchar* data, const CaptureRect& captureR
     for (int y = 1; y <= captureRect.targetHeight; ++y) {
 
     //Quick fix for iOS & macOS devices. Will be handled better in the future
-#if defined(Q_OS_IOS) || defined (Q_OS_MAC) || defined(Q_OS_SAILFISH)
+#if defined(Q_OS_IOS) || defined (Q_OS_MAC) || defined(Q_OS_SAILFISH) || defined(Q_OS_UBUNTUTOUCH)
         uchar* pixel = pixelInit + (y - 1) * captureRect.targetWidth;
 #else
         uchar* pixel = pixelInit + (captureRect.targetHeight - y) * captureRect.targetWidth;


### PR DESCRIPTION
With qtubuntu-camera gaining basic viewfinder mapping support it
is possible to make use of QZXingFilter in Ubuntu Touch apps.

Consumers of the library may either use 'CONFIG+=ubports' in their
qmake projects, or define Q_OS_UBUNTUTOUCH themselves when using
CMake since QZXing can easily be built as a subproject.

Fixes: https://github.com/ftylitak/qzxing/issues/203