### PR TITLE
Fix freezes for QZXing on Android with Qt 6.5

### DIFF
--- a/src/QZXingFilterVideoSink.cpp
+++ b/src/QZXingFilterVideoSink.cpp
@@ -59,7 +59,7 @@ void QZXingFilter::setVideoSink(QObject *videoSink){
 }
 
 void QZXingFilter::processFrame(const QVideoFrame &frame) {
-#ifdef Q_OS_ANDROID
+#if defined Q_OS_ANDROID && QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     m_videoSink->setRhi(nullptr); // https://bugreports.qt.io/browse/QTBUG-97789
     QVideoFrame f(frame);
     f.map(QVideoFrame::ReadOnly);
@@ -108,7 +108,7 @@ void QZXingFilter::processFrame(const QVideoFrame &frame) {
         });
     }
 
-#ifdef Q_OS_ANDROID
+#if defined Q_OS_ANDROID && QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     f.unmap();
 #endif
 }


### PR DESCRIPTION
Workaround for [QTBUG-97789](https://bugreports.qt.io/browse/QTBUG-97789) might cause extreamly freezes when scanning codes on some devices. Freezes are caused by calling map() method of QVideoFrame object. However, in Qt 6.5.0, the problem described in the [QTBUG-97789](https://bugreports.qt.io/browse/QTBUG-97789)  is not reproduced, so the workaround is no longer necessary.