### PR TITLE
Fix application crashes when page with QZXing closes

### DIFF
--- a/src/QZXingFilterVideoSink.cpp
+++ b/src/QZXingFilterVideoSink.cpp
@@ -55,7 +55,7 @@ int QZXingFilter::orientation() const
 void QZXingFilter::setVideoSink(QObject *videoSink){
     m_videoSink = qobject_cast<QVideoSink*>(videoSink);
 
-    connect(m_videoSink, &QVideoSink::videoFrameChanged, this, &QZXingFilter::processFrame);
+    connect(m_videoSink, &QVideoSink::videoFrameChanged, this, &QZXingFilter::processFrame, Qt::QueuedConnection);
 }
 
 void QZXingFilter::processFrame(const QVideoFrame &frame) {


### PR DESCRIPTION
Sometimes, when page with active scanner closes, QZXingFilter is still processing frame but that frame has already been removed with QVideoSink. So, application may be crashed. Qt::QueuedConnection fixes this problem.