### PR TITLE
Fix application crashes when activate application after deactivating

### DIFF
--- a/src/QZXingFilterVideoSink.cpp
+++ b/src/QZXingFilterVideoSink.cpp
@@ -59,6 +59,10 @@ void QZXingFilter::setVideoSink(QObject *videoSink){
 }
 
 void QZXingFilter::processFrame(const QVideoFrame &frame) {
+    if (!frame.isReadable()) {
+        return;
+    }
+
 #ifdef Q_OS_ANDROID
     m_videoSink->setRhi(nullptr); // https://bugreports.qt.io/browse/QTBUG-97789
     QVideoFrame f(frame);


### PR DESCRIPTION
How to reproduce: open the QZXingLive example on Android, switch to another app, switch to the QZXingLive example (or turn off then turn on the device screen) - the app will crash.
Frame readability check fixes this issue.