### PR TITLE
Add pkg-config export to CMake script

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,15 @@
 cmake_minimum_required(VERSION 3.3)
 project(QZXing)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 option(BUILD_SHARED "Build as shared library" OFF)
 
 if(BUILD_SHARED)
     SET(SOVERSION_MAJOR 3)
     SET(SOVERSION_MINOR 3)
     SET(SOVERSION_PATCH 0)
+    SET(SOVERSION_FULL "${SOVERSION_MAJOR}.${SOVERSION_MINOR}.${SOVERSION_PATCH}")
 
     OPTION(QZXING_MULTIMEDIA "" OFF)
     OPTION(QZXING_USE_QML "" OFF)
@@ -39,6 +42,8 @@ set(PUBLIC_HEADERS
     QZXing_global.h
 )
 
+set(PUBLIC_DEFINES "")
+
 set(SOURCES
 
     CameraImageWrapper.cpp
@@ -53,7 +58,7 @@ if(QZXING_MULTIMEDIA)
 
     LIST(APPEND SOURCES QZXingFilter.cpp QZXingFilter.h)
     LIST(APPEND PUBLIC_HEADERS QZXingFilter.h)
-    add_definitions(-DQZXING_MULTIMEDIA)
+    LIST(APPEND PUBLIC_DEFINES QZXING_MULTIMEDIA)
 
     SET(QZXING_USE_QML ON)
 
@@ -62,18 +67,18 @@ endif(QZXING_MULTIMEDIA)
 if(QZXING_USE_QML)
     LIST(APPEND SOURCES QZXingImageProvider.cpp QZXingImageProvider.h)
     LIST(APPEND PUBLIC_HEADERS QZXingImageProvider.h)
-    add_definitions(-DQZXING_QML)
+    LIST(APPEND PUBLIC_DEFINES QZXING_QML)
 endif(QZXING_USE_QML)
 
 if(QZXING_USE_ENCODER)
-    add_definitions(-DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
+    LIST(APPEND PUBLIC_DEFINES ENABLE_ENCODER_GENERIC ENABLE_ENCODER_QR_CODE)
 endif(QZXING_USE_ENCODER)
 
 if(BUILD_SHARED)
     add_library(qzxing SHARED ${SOURCES})
     set_target_properties(qzxing
         PROPERTIES
-        VERSION ${SOVERSION_MAJOR}.${SOVERSION_MINOR}.${SOVERSION_PATCH}
+        VERSION ${SOVERSION_FULL}
         SOVERSION ${SOVERSION_MAJOR}
 )
 else()
@@ -105,7 +110,6 @@ target_link_libraries(qzxing Qt5::Core Qt5::Gui)
 
 if(QZXING_MULTIMEDIA)
     target_link_libraries(qzxing Qt5::Multimedia)
-    target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
@@ -113,12 +117,7 @@ if(QZXING_USE_QML)
         Qt5::Svg
         Qt5::Quick
         Qt5::QuickControls2)
-    target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
-
-if(QZXING_USE_ENCODER)
-    target_compile_definitions(qzxing PUBLIC -DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
-endif(QZXING_USE_ENCODER)
 
 if(QZXING_USE_DECODER_QR_CODE)
     target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_QR_CODE)
@@ -146,8 +145,10 @@ endif()
 
 if(!BUILD_SHARED)
     # Change Global Definitions depending on how you want to use the library
-    target_compile_definitions(qzxing PUBLIC DISABLE_LIBRARY_FEATURES)
+    list(APPEND PUBLIC_DEFINES DISABLE_LIBRARY_FEATURES)
 endif()
+
+target_compile_definitions(qzxing PUBLIC ${PUBLIC_DEFINES})
 
 # Target includes
 target_include_directories(qzxing
@@ -163,6 +164,7 @@ target_include_directories(qzxing
 
 if(BUILD_SHARED)
     include (GNUInstallDirs)
+    include (JoinPaths)
 
     set(QZXING_INSTALL_TARGETS qzxing)
 
@@ -176,4 +178,15 @@ if(BUILD_SHARED)
     install (
         FILES ${PUBLIC_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qzxing"
     )
+
+    join_paths(PC_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+    join_paths(PC_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}" "qzxing")
+
+    string(REPLACE ";" " -D" PC_DEFINES "${PUBLIC_DEFINES}")
+    if(PC_DEFINES)
+        set(PC_DEFINES "-D${PC_DEFINES}")
+    endif()
+
+    configure_file(QZXing.pc.in ${CMAKE_CURRENT_BINARY_DIR}/QZXing.pc @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QZXing.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,27 @@
 cmake_minimum_required(VERSION 3.3)
 project(QZXing)
 
+option(BUILD_SHARED "Build as shared library" OFF)
+
+if(BUILD_SHARED)
+    SET(SOVERSION_MAJOR 3)
+    SET(SOVERSION_MINOR 3)
+    SET(SOVERSION_PATCH 0)
+
+    OPTION(QZXING_MULTIMEDIA "" OFF)
+    OPTION(QZXING_USE_QML "" OFF)
+    OPTION(QZXING_USE_ENCODER "" OFF)
+    OPTION(QZXING_MULTIMEDIA "" OFF)
+    OPTION(QZXING_USE_QML "" OFF)
+    OPTION(QZXING_USE_ENCODER "" OFF)
+    OPTION(QZXING_USE_DECODER_QR_CODE "" OFF)
+    OPTION(QZXING_USE_DECODER_1D_BARCODES "" OFF)
+    OPTION(QZXING_USE_DECODER_DATA_MATRIX "" OFF)
+    OPTION(QZXING_USE_DECODER_AZTEC "" OFF)
+    OPTION(QZXING_USE_DECODER_PDF17 "" OFF)
+    OPTION(QZXING_USE_DECODER_1D_BARCODES "" OFF)
+endif()
+
 find_package(Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt5 COMPONENTS Gui REQUIRED)
 find_package(Qt5 COMPONENTS Multimedia )
@@ -13,6 +34,11 @@ SET(ZXING_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/zxing)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_WARN_ON)
 
+set(PUBLIC_HEADERS
+    QZXing.h
+    QZXing_global.h
+)
+
 set(SOURCES
 
     CameraImageWrapper.cpp
@@ -20,13 +46,13 @@ set(SOURCES
     ImageHandler.cpp
     ImageHandler.h
     QZXing.cpp
-    QZXing.h
-    QZXing_global.h
+    ${PUBLIC_HEADERS}
     )
 
 if(QZXING_MULTIMEDIA)
 
     LIST(APPEND SOURCES QZXingFilter.cpp QZXingFilter.h)
+    LIST(APPEND PUBLIC_HEADERS QZXingFilter.h)
     add_definitions(-DQZXING_MULTIMEDIA)
 
     SET(QZXING_USE_QML ON)
@@ -35,6 +61,7 @@ endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
     LIST(APPEND SOURCES QZXingImageProvider.cpp QZXingImageProvider.h)
+    LIST(APPEND PUBLIC_HEADERS QZXingImageProvider.h)
     add_definitions(-DQZXING_QML)
 endif(QZXING_USE_QML)
 
@@ -42,7 +69,16 @@ if(QZXING_USE_ENCODER)
     add_definitions(-DENABLE_ENCODER_GENERIC -DENABLE_ENCODER_QR_CODE)
 endif(QZXING_USE_ENCODER)
 
-add_library(qzxing "" ${SOURCES})
+if(BUILD_SHARED)
+    add_library(qzxing SHARED ${SOURCES})
+    set_target_properties(qzxing
+        PROPERTIES
+        VERSION ${SOVERSION_MAJOR}.${SOVERSION_MINOR}.${SOVERSION_PATCH}
+        SOVERSION ${SOVERSION_MAJOR}
+)
+else()
+    add_library(qzxing "" ${SOURCES})
+endif()
 
 if(WIN32)
     add_subdirectory(zxing/win32)
@@ -108,9 +144,10 @@ if(QZXING_USE_DECODER_1D_BARCODES)
     target_compile_definitions(qzxing PRIVATE -DENABLE_DECODER_1D_BARCODES)
 endif()
 
-
-# Change Global Definitions depending on how you want to use the library
-target_compile_definitions(qzxing PUBLIC DISABLE_LIBRARY_FEATURES)
+if(!BUILD_SHARED)
+    # Change Global Definitions depending on how you want to use the library
+    target_compile_definitions(qzxing PUBLIC DISABLE_LIBRARY_FEATURES)
+endif()
 
 # Target includes
 target_include_directories(qzxing
@@ -120,7 +157,23 @@ target_include_directories(qzxing
         zxing/win32/zxing
         zxing/zxing
         zxing/bigint
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
+if(BUILD_SHARED)
+    include (GNUInstallDirs)
+
+    set(QZXING_INSTALL_TARGETS qzxing)
+
+    install (
+        TARGETS ${QZXING_INSTALL_TARGETS} EXPORT QZXingTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+
+    install (
+        FILES ${PUBLIC_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qzxing"
+    )
+endif()

--- a/src/QZXing.pc.in
+++ b/src/QZXing.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@PC_LIBDIR@
+includedir=@PC_INCLUDEDIR@
+
+Name: Qzxing
+Description: Qzxing Library
+Version: @SOVERSION_FULL@
+Cflags: @PC_DEFINES@ -I${includedir}
+Libs: -L${libdir} -lqzxing

--- a/src/cmake/JoinPaths.cmake
+++ b/src/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Based on & includes #222.

Working on closing downstream issue https://gitlab.com/ubports/development/apps/lomiri-camera-app/-/issues/209.

The QMake script has code for generating a pkg-config file, which the CMake one lacks.

https://github.com/ftylitak/qzxing/blob/6ea2b31e26db9d43db027ba207f5c73dc9d759fc/src/QZXing-components.pri#L464-L468

This adds code to the CMake script to also generate a pkg-config file, which allows the unconditional use of pkg-config to gather flags for an installed QZXing library.

An example:
```
↪ cat /nix/store/i6gd51yg61b0ipfcan10q30phpkzz4bc-qzxing-3.3.0/lib/pkgconfig/QZXing.pc 
prefix=/nix/store/i6gd51yg61b0ipfcan10q30phpkzz4bc-qzxing-3.3.0
exec_prefix=${prefix}
libdir=/nix/store/i6gd51yg61b0ipfcan10q30phpkzz4bc-qzxing-3.3.0/lib
includedir=/nix/store/i6gd51yg61b0ipfcan10q30phpkzz4bc-qzxing-3.3.0/include/qzxing

Name: Qzxing
Description: Qzxing Library
Version: 3.3.0
Cflags: -DQZXING_MULTIMEDIA -DQZXING_QML -DDISABLE_LIBRARY_FEATURES -I${includedir}
Libs: -L${libdir} -lqzxing
```