### PR TITLE
update CMakeLists to build with Qt 6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.3)
 project(QZXing)
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt5 COMPONENTS Gui REQUIRED)
-find_package(Qt5 COMPONENTS Multimedia )
-find_package(Qt5 REQUIRED Svg Quick QuickControls2)
+find_package(QT NAMES Qt6)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui)
+find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Multimedia Quick QuickControls2 Svg)
+
+qt_standard_project_setup(REQUIRES 6.5)
 
 SET(BIGINT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxing/bigint)
 SET(WIN32_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/win32/zxing)
@@ -26,7 +27,7 @@ set(SOURCES
 
 if(QZXING_MULTIMEDIA)
 
-    LIST(APPEND SOURCES QZXingFilter.cpp QZXingFilter.h)
+    LIST(APPEND SOURCES QZXingFilterVideoSink.cpp QZXingFilterVideoSink.h)
     add_definitions(-DQZXING_MULTIMEDIA)
 
     SET(QZXING_USE_QML ON)
@@ -65,18 +66,18 @@ add_subdirectory(zxing/bigint)
 
 add_subdirectory(zxing/zxing)
 
-target_link_libraries(qzxing Qt5::Core Qt5::Gui)
+target_link_libraries(qzxing Qt::Core Qt::Gui)
 
 if(QZXING_MULTIMEDIA)
-    target_link_libraries(qzxing Qt5::Multimedia)
+    target_link_libraries(qzxing Qt::Multimedia)
     target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
     target_link_libraries(qzxing
-        Qt5::Svg
-        Qt5::Quick
-        Qt5::QuickControls2)
+        Qt::Svg
+        Qt::Quick
+        Qt::QuickControls2)
     target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(QT NAMES Qt6)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Multimedia Quick QuickControls2 Svg)
 
-qt_standard_project_setup(REQUIRES 6.5)
+qt_standard_project_setup(REQUIRES 6.8)
 
 SET(BIGINT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxing/bigint)
 SET(WIN32_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/win32/zxing)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.17)
 project(QZXing)
 
 find_package(QT NAMES Qt6)

--- a/src/QZXingFilterVideoSink.h
+++ b/src/QZXingFilterVideoSink.h
@@ -31,7 +31,7 @@ class QZXingFilter : public QObject
     Q_PROPERTY(bool decoding READ isDecoding NOTIFY isDecodingChanged)
     Q_PROPERTY(QZXing* decoder READ getDecoder)
     Q_PROPERTY(QRectF captureRect MEMBER captureRect NOTIFY captureRectChanged)
-    Q_PROPERTY(QObject* videoSink WRITE setVideoSink)
+    Q_PROPERTY(QObject* videoSink READ getVideoSink WRITE setVideoSink)
     Q_PROPERTY(int orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
 
     signals:
@@ -64,6 +64,9 @@ class QZXingFilter : public QObject
 
         bool isDecoding() {return decoding; }
         QZXing* getDecoder() { return &decoder; }
+
+    private: /// Methods
+        QVideoSink* getVideoSink() { return m_videoSink; }
 };
 
 #endif // QZXingFilter_H

--- a/src/zxing/zxing/ResultIO.cpp
+++ b/src/zxing/zxing/ResultIO.cpp
@@ -24,7 +24,8 @@
 using zxing::Result;
 using std::ostream;
 
-ostream& zxing::operator<<(ostream &out, Result& result) {
+namespace zxing {
+ostream& operator<<(ostream &out, Result& result) {
   if (result.text_ != 0) {
     out << result.text_->getText();
   } else {
@@ -32,3 +33,4 @@ ostream& zxing::operator<<(ostream &out, Result& result) {
   }
   return out;
 }
+} // namespace zxing


### PR DESCRIPTION
The provided src/CMakeLists.txt was setup for Qt5, with little adjustments it works perfectly with Qt6.
I set the minimum Qt version to 6.5 since it's the oldest still officially supported, and hence removed the support for Qt5. Anyway, the file could be configured to still support both versions.
Since Qt is also abandoning qmake in favor of cmake, it is crucial to have an updated CMakeLists.txt to build qzxing with cmake.